### PR TITLE
[Hotfix] Iterate through collection names to check if it exists already

### DIFF
--- a/extractive_qa/extractive-question-answering.ipynb
+++ b/extractive_qa/extractive-question-answering.ipynb
@@ -389,7 +389,7 @@
     "print(collections)\n",
     "\n",
     "# only create collection if it doesn't exist\n",
-    "if collection_name not in [c.name for c in collections]:\n",
+    "if collection_name not in [c.name for c in collections.collections]:\n",
     "    client.recreate_collection(\n",
     "        collection_name=collection_name,\n",
     "        vectors_config=models.VectorParams(\n",

--- a/extractive_qa/extractive-question-answering.ipynb
+++ b/extractive_qa/extractive-question-answering.ipynb
@@ -389,7 +389,7 @@
     "print(collections)\n",
     "\n",
     "# only create collection if it doesn't exist\n",
-    "if collection_name not in collections:\n",
+    "if collection_name not in [c.name for c in collections]:\n",
     "    client.recreate_collection(\n",
     "        collection_name=collection_name,\n",
     "        vectors_config=models.VectorParams(\n",


### PR DESCRIPTION
This is a hotfix, as the notebook checked the existence of a collection name with a wrong condition. The `get_collections` method does not return collection names as a list of strings but as a list of `CollectionDescription` objects.