### PR TITLE
fix(quickstart.ipynb): fix typo in query_text variable name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ qdrant_101_image_data/vecs.npy
 data
 qdrant_101_image_data/vectors.npy
 qdrant_101_image_data/image_search_app.py
+quickstart/local_cache/*

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -2,9 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
    "source": [
     "# install qdrant\n",
     "!pip install fastembed qdrant-client"
@@ -12,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,14 +38,37 @@
     "    {\"source\": \"Langchain-docs\"},\n",
     "    {\"source\": \"Linkedin-docs\"},\n",
     "]\n",
-    "ids = [42, 2]\n",
+    "ids = [42, 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[QueryResponse(id='f6ac2af4c0574058b140754a8e4e8450', embedding=None, metadata={'document': 'documents'}, document='documents', score=0.8273301519088604), QueryResponse(id='40081101976140acaee79a59ebd89b85', embedding=None, metadata={'document': 'metadatas'}, document='metadatas', score=0.8051243540246182), QueryResponse(id='a17d3741f7814a7d922e8171d5e15524', embedding=None, metadata={'document': 'ids'}, document='ids', score=0.7791742722774597)]\n"
+     ]
+    }
+   ],
+   "source": [
     "\n",
     "# Use the new add method\n",
     "client.add(collection_name=\"demo_collection\", documents={\"documents\": docs, \"metadatas\": metadatas, \"ids\": ids})\n",
     "\n",
-    "search_result = client.query(collection_name=\"demo_collection\", query_texts=[\"This is a query document\"])\n",
+    "search_result = client.query(collection_name=\"demo_collection\", query_text=[\"This is a query document\"])\n",
     "print(search_result)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -53,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* fix(quickstart.ipynb): fix typo in query_text variable name
* feat(quickstart.ipynb): leave outputs inline