### PR TITLE
docs: New BQ example - P2

### DIFF
--- a/binary-quantization-qdrant/bq_with_qdrant.ipynb
+++ b/binary-quantization-qdrant/bq_with_qdrant.ipynb
@@ -1,0 +1,480 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XSIFeqQjRyQN"
+      },
+      "source": [
+        "# Binary Quantization with Qdrant\n",
+        "\n",
+        "This notebook demonstrates/evaluates the search performance of Qdrant with Binary Quantization. We will use [Qdrant Cloud](https://qdrant.to/cloud?utm_source=qdrant&utm_medium=social&utm_campaign=binary-openai-v3&utm_content=article) to index and search the embeddings. This demo can be carried out on a free-tier Qdrant cluster as well."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "l-BroS-tRyQQ"
+      },
+      "source": [
+        "# Set Up Binary Quantization\n",
+        "\n",
+        "Let's install the 2 Python packages we'll work with."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nYyAQSsWXdAQ"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install qdrant-client datasets"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zZM2xsHiAd6E"
+      },
+      "source": [
+        "For the demo, We use samples from the [Qdrant/dbpedia-entities-openai3-text-embedding-3-small-1536-100K](https://huggingface.co/datasets/Qdrant/dbpedia-entities-openai3-text-embedding-3-small-1536-100K) dataset. The dataset includes embeddings generated using OpenAI's `text-embedding-3-small` model.\n",
+        "\n",
+        "You can use your own datasets for this evaluation by adjusting the config values below.\n",
+        "\n",
+        "We select 100 records at random from the dataset. We then use the embeddings of the queries to search for the nearest neighbors in the dataset."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U5Fwlha0DaY7"
+      },
+      "source": [
+        "## Configure Credentials"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "id": "3iq_y8zJRyQR"
+      },
+      "outputs": [],
+      "source": [
+        "# QDRANT CONFIG\n",
+        "URL=\"https://xyz-example.eu-central.aws.cloud.qdrant.io:6333\"\n",
+        "API_KEY=\"<provide-your-own-key>\"\n",
+        "COLLECTION_NAME=\"bq-evaluation\"\n",
+        "\n",
+        "# EMBEDDING CONFIG\n",
+        "DATASET_NAME = \"Qdrant/dbpedia-entities-openai3-text-embedding-3-small-1536-100K\"\n",
+        "DIMENSIONS = 1536\n",
+        "EMBEDDING_COLUMN_NAME = \"text-embedding-3-small-1536-embedding\"\n",
+        "\n",
+        "## UPLOAD CONFIG\n",
+        "BATCH_SIZE = 1024 # Batch size for uploading points\n",
+        "PARALLEL = 1 # Number of parallel processes for uploading points"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5h_2XjkADjED"
+      },
+      "source": [
+        "## Setup A Qdrant Collection\n",
+        "\n",
+        "Let's create a Qdrant collection to index our vectors. We set `on_disk` in the vectors config to `True` offload the original vectors to disk to save memory."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Mqj6NNU-RyQS"
+      },
+      "outputs": [],
+      "source": [
+        "from datasets import load_dataset\n",
+        "from qdrant_client import QdrantClient, models\n",
+        "import logging\n",
+        "\n",
+        "from tqdm import tqdm\n",
+        "\n",
+        "client = QdrantClient(\n",
+        "    url=URL,\n",
+        "    api_key=API_KEY\n",
+        ")\n",
+        "\n",
+        "if not client.collection_exists(COLLECTION_NAME):\n",
+        "    client.create_collection(\n",
+        "        collection_name=COLLECTION_NAME,\n",
+        "        vectors_config=models.VectorParams(\n",
+        "            size=DIMENSIONS,\n",
+        "            distance=models.Distance.COSINE,\n",
+        "            on_disk=True\n",
+        "        ),\n",
+        "        quantization_config=models.BinaryQuantization(\n",
+        "            binary=models.BinaryQuantizationConfig(always_ram=False),\n",
+        "        ),\n",
+        "    )\n",
+        "    logging.info(f\"Created collection {COLLECTION_NAME}\")\n",
+        "else:\n",
+        "    collection_info = client.get_collection(collection_name=COLLECTION_NAME)\n",
+        "    logging.info(f\"Collection {COLLECTION_NAME} already exists with {collection_info.points_count} points.\")\n",
+        "\n",
+        "logging.info(\"Loading Dataset\")\n",
+        "dataset = load_dataset(\n",
+        "    DATASET_NAME,\n",
+        "    split=\"train\",\n",
+        ")\n",
+        "logging.info(f\"Loaded {DATASET_NAME} dataset\")\n",
+        "\n",
+        "logging.info(\"Loading Points\")\n",
+        "points = [\n",
+        "    models.PointStruct(id=i, vector=embedding)\n",
+        "    for i, embedding in enumerate(dataset[EMBEDDING_COLUMN_NAME])\n",
+        "]\n",
+        "logging.info(f\"Loaded {len(points)} points\")\n",
+        "\n",
+        "logging.info(\"Uploading Points\")\n",
+        "client.upload_points(COLLECTION_NAME, points=tqdm(points), batch_size=BATCH_SIZE)\n",
+        "logging.info(f\"Collection {COLLECTION_NAME} is ready\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ncRv-LBj_-MK"
+      },
+      "source": [
+        "## Evaluate Results\n",
+        "\n",
+        "### Parameters: Oversampling, Rescoring, and Search Limits\n",
+        "\n",
+        "For each record, we run a parameter sweep over the number of oversampling, rescoring, and search limits. We can then understand the impact of these parameters on search accuracy and efficiency. Our experiment was designed to assess the impact of Binary Quantization under various conditions, based on the following parameters:\n",
+        "\n",
+        "- **Oversampling**: By oversampling, we can limit the loss of information inherent in quantization. We experimented with different oversampling factors, and identified the impact on the accuracy and efficiency of search. Spoiler: higher oversampling factors tend to improve the accuracy of searches. However, they usually require more computational resources.\n",
+        "\n",
+        "- **Rescoring**: Rescoring refines the first results of an initial binary search. This process leverages the original high-dimensional vectors to refine the search results, **always** improving accuracy. We toggled rescoring on and off to measure effectiveness, when combined with Binary Quantization. We also measured the impact on search performance.\n",
+        "\n",
+        "- **Search Limits**: We specify the number of results from the search process. We experimented with various search limits to measure their impact the accuracy and efficiency. We explored the trade-offs between search depth and performance. The results provide insight for applications with different precision and speed requirements.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WHllRnNfRyQT"
+      },
+      "source": [
+        "# Parameterized Search\n",
+        "\n",
+        "We will compare the exact search performance with the approximate search performance."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {
+        "id": "p8mriYRlRyQT"
+      },
+      "outputs": [],
+      "source": [
+        "def parameterized_search(\n",
+        "    point,\n",
+        "    oversampling: float,\n",
+        "    rescore: bool,\n",
+        "    exact: bool,\n",
+        "    collection_name: str,\n",
+        "    ignore: bool = False,\n",
+        "    limit: int = 10,\n",
+        "):\n",
+        "    if exact:\n",
+        "        return client.query_points(\n",
+        "            collection_name=collection_name,\n",
+        "            query=point.vector,\n",
+        "            search_params=models.SearchParams(exact=exact),\n",
+        "            limit=limit,\n",
+        "        ).points\n",
+        "    else:\n",
+        "        return client.query_points(\n",
+        "            collection_name=collection_name,\n",
+        "            query=point.vector,\n",
+        "            search_params=models.SearchParams(\n",
+        "                quantization=models.QuantizationSearchParams(\n",
+        "                    ignore=ignore,\n",
+        "                    rescore=rescore,\n",
+        "                    oversampling=oversampling,\n",
+        "                ),\n",
+        "                exact=exact,\n",
+        "            ),\n",
+        "            limit=limit,\n",
+        "        ).points\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "2gRLBGu4RyQU"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import random\n",
+        "import numpy as np\n",
+        "\n",
+        "oversampling_range = np.arange(1.0, 3.1, 1.0)\n",
+        "rescore_range = [True, False]\n",
+        "\n",
+        "ds = dataset.train_test_split(test_size=0.001, shuffle=True, seed=37)[\"test\"]\n",
+        "ds = ds.to_pandas().to_dict(orient=\"records\")\n",
+        "\n",
+        "results = []\n",
+        "with open(f\"bq/{COLLECTION_NAME}.json\", \"w+\") as f:\n",
+        "    for element in tqdm(ds):\n",
+        "        point = models.PointStruct(\n",
+        "            id=random.randint(0, 100000),\n",
+        "            vector=element[EMBEDDING_COLUMN_NAME],\n",
+        "        )\n",
+        "        ## Running Grid Search\n",
+        "        for oversampling in oversampling_range:\n",
+        "            for rescore in rescore_range:\n",
+        "                limit_range = [100, 50, 20, 10, 5]\n",
+        "                for limit in limit_range:\n",
+        "                    try:\n",
+        "                        exact = parameterized_search(\n",
+        "                            point=point,\n",
+        "                            oversampling=oversampling,\n",
+        "                            rescore=rescore,\n",
+        "                            exact=True,\n",
+        "                            collection_name=COLLECTION_NAME,\n",
+        "                            limit=limit,\n",
+        "                        )\n",
+        "                        hnsw = parameterized_search(\n",
+        "                            point=point,\n",
+        "                            oversampling=oversampling,\n",
+        "                            rescore=rescore,\n",
+        "                            exact=False,\n",
+        "                            collection_name=COLLECTION_NAME,\n",
+        "                            limit=limit,\n",
+        "                        )\n",
+        "                    except Exception as e:\n",
+        "                        print(f\"Skipping point: {point}\\n{e}\")\n",
+        "                        continue\n",
+        "\n",
+        "                    exact_ids = [item.id for item in exact]\n",
+        "                    hnsw_ids = [item.id for item in hnsw]\n",
+        "\n",
+        "                    accuracy = len(set(exact_ids) & set(hnsw_ids)) / len(exact_ids)\n",
+        "\n",
+        "                    result = {\n",
+        "                        \"query_id\": point.id,\n",
+        "                        \"oversampling\": oversampling,\n",
+        "                        \"rescore\": rescore,\n",
+        "                        \"limit\": limit,\n",
+        "                        \"accuracy\": accuracy,\n",
+        "                    }\n",
+        "                    f.write(json.dumps(result))\n",
+        "                    f.write(\"\\n\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "HSfGG_RhGrh5"
+      },
+      "source": [
+        "## View The Results\n",
+        "\n",
+        "We can now tabulate our results across the ranges of oversampling and rescoring."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uNj39SwAvDix"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "results = pd.read_json(f\"bq/{COLLECTION_NAME}.json\", lines=True)\n",
+        "\n",
+        "average_accuracy = results[results[\"limit\"] != 1]\n",
+        "average_accuracy = average_accuracy[average_accuracy[\"limit\"] != 5]\n",
+        "average_accuracy = average_accuracy.groupby([\"oversampling\", \"rescore\", \"limit\"])[\n",
+        "    \"accuracy\"\n",
+        "].mean()\n",
+        "average_accuracy = average_accuracy.reset_index()\n",
+        "\n",
+        "acc = average_accuracy.pivot(\n",
+        "    index=\"limit\", columns=[\"oversampling\", \"rescore\"], values=\"accuracy\"\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 238
+        },
+        "id": "S64Es1BY9ISp",
+        "outputId": "eff1111a-dc19-47e3-ff78-4bf48b6d5031"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr>\n",
+              "      <th>oversampling</th>\n",
+              "      <th colspan=\"2\" halign=\"left\">1</th>\n",
+              "      <th colspan=\"2\" halign=\"left\">2</th>\n",
+              "      <th colspan=\"2\" halign=\"left\">3</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>rescore</th>\n",
+              "      <th>False</th>\n",
+              "      <th>True</th>\n",
+              "      <th>False</th>\n",
+              "      <th>True</th>\n",
+              "      <th>False</th>\n",
+              "      <th>True</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>limit</th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>0.6950</td>\n",
+              "      <td>0.9430</td>\n",
+              "      <td>0.6950</td>\n",
+              "      <td>0.9860</td>\n",
+              "      <td>0.6950</td>\n",
+              "      <td>0.9930</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>20</th>\n",
+              "      <td>0.7050</td>\n",
+              "      <td>0.9520</td>\n",
+              "      <td>0.7050</td>\n",
+              "      <td>0.9860</td>\n",
+              "      <td>0.7050</td>\n",
+              "      <td>0.9915</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>50</th>\n",
+              "      <td>0.6962</td>\n",
+              "      <td>0.9546</td>\n",
+              "      <td>0.6962</td>\n",
+              "      <td>0.9838</td>\n",
+              "      <td>0.6968</td>\n",
+              "      <td>0.9926</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>100</th>\n",
+              "      <td>0.6991</td>\n",
+              "      <td>0.9561</td>\n",
+              "      <td>0.7003</td>\n",
+              "      <td>0.9904</td>\n",
+              "      <td>0.7007</td>\n",
+              "      <td>0.9964</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from IPython.display import display, HTML\n",
+        "\n",
+        "display(HTML(acc.to_html()))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qrTOLInb-1iq"
+      },
+      "source": [
+        "## Results\n",
+        "\n",
+        "\n",
+        "Here are some key observations, which analyzes the impact of rescoring (`True` or `False`):\n",
+        "\n",
+        "1. **Significantly Improved Accuracy**:\n",
+        "   - Enabling rescoring (`True`) consistently results in higher accuracy scores compared to when rescoring is disabled (`False`).\n",
+        "   - The improvement in accuracy is true across various search limits (10, 20, 50, 100).\n",
+        "\n",
+        "2. **Model and Dimension Specific Observations**:\n",
+        "    - Th results suggest a diminishing return on accuracy improvement with higher oversampling in lower dimension spaces.\n",
+        "\n",
+        "3. **Influence of Search Limit**:\n",
+        "   - The performance gain from rescoring seems to be relatively stable across different search limits, suggesting that rescoring consistently enhances accuracy regardless of the number of top results considered.\n",
+        "\n",
+        "In summary, enabling rescoring dramatically improves search accuracy across all tested configurations. It is crucial feature for applications where precision is paramount. The consistent performance boost provided by rescoring underscores its value in refining search results, particularly when working with complex, high-dimensional data. This enhancement is critical for applications that demand high accuracy, such as semantic search, content discovery, and recommendation systems, where the quality of search results directly impacts user experience and satisfaction.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2GECBQdg_heH"
+      },
+      "source": [
+        "## Leveraging Binary Quantization: Best Practices\n",
+        "\n",
+        "We recommend the following best practices for leveraging Binary Quantization:\n",
+        "\n",
+        "1. Oversampling: Use an oversampling factor of 3 for the best balance between accuracy and efficiency. This factor is suitable for a wide range of applications.\n",
+        "2. Rescoring: Enable rescoring to improve the accuracy of search results.\n",
+        "3. RAM: Store the full vectors and payload on disk. Limit what you load from memory to the binary quantization index. This helps reduce the memory footprint and improve the overall efficiency of the system. The incremental latency from the disk read is negligible compared to the latency savings from the binary scoring in Qdrant, which uses SIMD instructions where possible.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "TPU",
+    "colab": {
+      "gpuType": "V28",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/binary-quantization-qdrant/bq_with_qdrant.ipynb
+++ b/binary-quantization-qdrant/bq_with_qdrant.ipynb
@@ -103,6 +103,8 @@
         "\n",
         "from tqdm import tqdm\n",
         "\n",
+        "logging.basicConfig(level=logging.INFO)\n",
+        "\n",
         "client = QdrantClient(\n",
         "    url=URL,\n",
         "    api_key=API_KEY\n",


### PR DESCRIPTION
Adds a new BQ evaluation example, `binary-quantization-qdrant` that can be run on any HF dataset with embeddings.
Default dataset used is `Qdrant/dbpedia-entities-openai3-text-embedding-3-small-1536-100K`.