### PR TITLE
Add scale-ceiling note to incremental embedding updates notebook

### DIFF
--- a/temporal-data-drift/sync_raw_data_to_embeddings.ipynb
+++ b/temporal-data-drift/sync_raw_data_to_embeddings.ipynb
@@ -36,6 +36,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Scale note.** This design re-reads the whole collection every run: it pulls\n",
+    "> every point's hash and diffs the full stored set against the incoming one, so\n",
+    "> per-run cost scales with corpus size, not with what changed. Around 100k chunks\n",
+    "> it stays cheap. By ~1M points each run moves hundreds of MB and hits Qdrant's\n",
+    "> 32 MB request cap ([`max_request_size_mb`](https://qdrant.tech/documentation/ops-configuration/configuration/));\n",
+    "> batching only splits the same full scan into more round trips. You scan the\n",
+    "> whole corpus to update a handful of chunks.\n",
+    ">\n",
+    "> A follow-up edition will cover a version that groups chunks into hash buckets\n",
+    "> and checks only the buckets that changed, so cost stays flat as the corpus grows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab192718",
    "metadata": {},
    "source": [

--- a/temporal-data-drift/sync_raw_data_to_embeddings.ipynb
+++ b/temporal-data-drift/sync_raw_data_to_embeddings.ipynb
@@ -38,16 +38,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Scale note.** This design re-reads the whole collection every run: it pulls\n",
-    "> every point's hash and diffs the full stored set against the incoming one, so\n",
-    "> per-run cost scales with corpus size, not with what changed. Around 100k chunks\n",
-    "> it stays cheap. By ~1M points each run moves hundreds of MB and hits Qdrant's\n",
-    "> 32 MB request cap ([`max_request_size_mb`](https://qdrant.tech/documentation/ops-configuration/configuration/));\n",
-    "> batching only splits the same full scan into more round trips. You scan the\n",
-    "> whole corpus to update a handful of chunks.\n",
+    "> **Scale note.** This design re-reads the whole collection on every run: it pulls\n",
+    "> every point's hash and diffs the full stored set against the incoming one.\n",
+    "> Per-run cost scales with corpus size, not with what actually changed. At around\n",
+    "> 100,000 points, this stays cheap. By around 1 million points, each run moves\n",
+    "> hundreds of MB and hits Qdrant's 32 MB request cap\n",
+    "> ([`max_request_size_mb`](https://qdrant.tech/documentation/ops-configuration/configuration/)).\n",
+    "> Batching doesn't help — it just splits the same full scan into more round trips.\n",
+    "> The result: a full corpus scan to update a handful of chunks.\n",
     ">\n",
     "> A follow-up edition will cover a version that groups chunks into hash buckets\n",
-    "> and checks only the buckets that changed, so cost stays flat as the corpus grows."
+    "> and checks only the buckets that changed, so cost stays flat as the corpus\n",
+    "> grows."
    ]
   },
   {


### PR DESCRIPTION
Adds a scale note to the notebook: the whole-corpus-per-run design is fine to ~100k chunks and hits Qdrant's 32 MB request cap around ~1M points; flags a bucketed follow-up edition. Mirrors the same note added to the tutorial page in landing_page.